### PR TITLE
allow tags for input

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -18,6 +18,7 @@ define telegraf::input (
   $options        = undef,
   $single_section = undef,
   $sections       = undef,
+  $tags           = undef,
 ) {
   include telegraf
 

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -12,6 +12,9 @@
 #
 # [*sections*]
 #   Hash. Some inputs take multiple sections in [[double brackets]].
+#
+# [*tags*]
+#   Hash. key/value pairs of tags to be applied to this input plugin.
 
 define telegraf::input (
   $plugin_type    = $name,

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -4,6 +4,14 @@
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%          end -%>
 <%      end -%>
+<% if @tags -%>
+  [inputs.<%= @plugin_type %>.tags]
+<%  @tags.sort.each do |tag, value| -%>
+<%         unless value == nil -%>
+    <%= tag -%> = "<%= value -%>"
+<%          end -%>
+<%      end -%>
+<%   end -%>
 <% if @sections -%>
 <% @sections.sort.each do |section, option| -%>
 [[inputs.<%= section %>]]


### PR DESCRIPTION
Allow creation of tags like input_source in puppet-generated conf files